### PR TITLE
Running CLI in local composer installation fails

### DIFF
--- a/bin/phpmig
+++ b/bin/phpmig
@@ -14,7 +14,14 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
     exit(1);
 }
 
-require __DIR__.'/../vendor/autoload.php';
+$baseDir   = dirname(__DIR__);
+$vendorDir = $baseDir . '/vendor';
+
+if (!file_exists($vendorDir . '/autoload.php')) {
+    $vendorDir = dirname(dirname($baseDir));
+}
+
+require $vendorDir . '/autoload.php';
 
 // Make it pass syntax parsing when PHP doesn't support namespace
 class_alias('PhpMigration\App', 'PhpMigration_App');


### PR DESCRIPTION
When you install PHP-Migration on CLI with command

```
php composer.phar require monque/php-migration
```

the vendor directory is not where you're supposed to be. 

NOTE: I've the same problem in past with my project https://github.com/llaville/php-compat-info/issues/126
