### PR TITLE
Add binary bindings to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
         "psr-4": {
             "PhpMigration\\": "src/"
         }
-    }
+    },
+    "bin": [
+        "bin/phpmig"
+    ]
 }


### PR DESCRIPTION
This will provide a link to phpmig in vendor/bin if the package is installed via composer.
