### PR TITLE
magic const trigger notice 

### DIFF
--- a/src/Changes/v5dot6/IncompPropertyArray.php
+++ b/src/Changes/v5dot6/IncompPropertyArray.php
@@ -6,6 +6,7 @@ use PhpMigration\Changes\AbstractChange;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Scalar\MagicConst;
 
 class IncompPropertyArray extends AbstractChange
 {
@@ -41,7 +42,9 @@ class IncompPropertyArray extends AbstractChange
                     }
                 } elseif ($stmt instanceof Stmt\ClassConst) {
                     foreach ($stmt->consts as $const) {
-                        if ($const->value instanceof Scalar) {
+                        if ($const->value instanceof MagicConst) {
+                            $const_table['self::'.$const->name] = $const->value->getName();
+                        } elseif ($const->value instanceof Scalar) {
                             $const_table['self::'.$const->name] = $const->value->value;
                         }
                     }

--- a/src/Changes/v5dot6/IncompPropertyArray.php
+++ b/src/Changes/v5dot6/IncompPropertyArray.php
@@ -3,7 +3,6 @@
 namespace PhpMigration\Changes\v5dot6;
 
 use PhpMigration\Changes\AbstractChange;
-use PhpParser\Node\Scalar\MagicConst;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt;
@@ -42,7 +41,7 @@ class IncompPropertyArray extends AbstractChange
                     }
                 } elseif ($stmt instanceof Stmt\ClassConst) {
                     foreach ($stmt->consts as $const) {
-                        if ($const->value instanceof MagicConst) {
+                        if ($const->value instanceof Scalar\MagicConst) {
                             $const_table['self::'.$const->name] = $const->value->getName();
                         } elseif ($const->value instanceof Scalar) {
                             $const_table['self::'.$const->name] = $const->value->value;

--- a/src/Changes/v5dot6/IncompPropertyArray.php
+++ b/src/Changes/v5dot6/IncompPropertyArray.php
@@ -3,10 +3,10 @@
 namespace PhpMigration\Changes\v5dot6;
 
 use PhpMigration\Changes\AbstractChange;
+use PhpParser\Node\Scalar\MagicConst;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Scalar\MagicConst;
 
 class IncompPropertyArray extends AbstractChange
 {

--- a/tests/Changes/v5dot6/IncompPropertyArrayTest.php
+++ b/tests/Changes/v5dot6/IncompPropertyArrayTest.php
@@ -93,5 +93,17 @@ class Sample
 }
 EOC;
         $this->assertNotSpot($code);
+
+        // MagicConst trigger warning
+        $code = <<<'EOC'
+class Sample
+{
+    const LOGTAG = __FUNCTION__;
+    public $data = array(
+        self::LOGTAG => 1
+    );
+}
+EOC;
+        $this->assertNotSpot($code);
     }
 }


### PR DESCRIPTION
when magic const as class property array key, trigger notice

```
PHP Notice:  Undefined property: PhpParser\Node\Scalar\MagicConst\Function_::$value in /Users/ruitao/.composer/vendor/monque/php-migration/src/Changes/v5dot6/IncompPropertyArray.php on line 48
PHP Stack trace:
PHP   1. {main}() /Users/ruitao/.composer/vendor/monque/php-migration/bin/phpmig:0
PHP   2. PhpMigration\App->run() /Users/ruitao/.composer/vendor/monque/php-migration/bin/phpmig:22
PHP   3. PhpMigration\App->commandMain() /Users/ruitao/.composer/vendor/monque/php-migration/src/App.php:194
PHP   4. PhpParser\NodeTraverser->traverse() /Users/ruitao/.composer/vendor/monque/php-migration/src/App.php:399
PHP   5. PhpParser\NodeTraverser->traverseArray() /Users/ruitao/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:64
PHP   6. PhpMigration\CheckVisitor->leaveNode() /Users/ruitao/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:139
PHP   7. PhpMigration\Changes\v5dot6\IncompPropertyArray->leaveNode() /Users/ruitao/.composer/vendor/monque/php-migration/src/CheckVisitor.php:176

Notice: Undefined property: PhpParser\Node\Scalar\MagicConst\Function_::$value in /Users/ruitao/.composer/vendor/monque/php-migration/src/Changes/v5dot6/IncompPropertyArray.php on line 48

Call Stack:
    0.0003     357680   1. {main}() /Users/ruitao/.composer/vendor/monque/php-migration/bin/phpmig:0
    0.0069     647360   2. PhpMigration\App->run() /Users/ruitao/.composer/vendor/monque/php-migration/bin/phpmig:22
    0.0069     648432   3. PhpMigration\App->commandMain() /Users/ruitao/.composer/vendor/monque/php-migration/src/App.php:194
    0.1112    4250888   4. PhpParser\NodeTraverser->traverse() /Users/ruitao/.composer/vendor/monque/php-migration/src/App.php:399
    0.1112    4250888   5. PhpParser\NodeTraverser->traverseArray() /Users/ruitao/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:64
    0.2436    4381640   6. PhpMigration\CheckVisitor->leaveNode() /Users/ruitao/.composer/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:139
    0.2438    4381616   7. PhpMigration\Changes\v5dot6\IncompPropertyArray->leaveNode() /Users/ruitao/.composer/vendor/monque/php-migration/src/CheckVisitor.php:176
```
